### PR TITLE
GitHubbers are now encouraged to stay home

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 | Cisco | Encouraged | Restricted | Restricted | Restricted | 2020-03-04 |
 | [Coinbase](https://docs.google.com/document/d/1SRP4dnVCvKB7A5WXrESe-cL51i6_cg5nNGLNld6qch0/edit) | Encouraged | ? | ? | ? | 2020-03-03 |
 | [Fastly](https://www.fastly.com/blog/exercising-caution-as-covid-19-evolves) | Required | Restricted | Restricted | Restricted | 2020-03-01 |
-| GitHub | ? | Restricted | ? | ? | 2020-03-03 |
+| GitHub | Encouraged | Restricted | ? | ? | 2020-03-04 |
 | [Google](https://www.theguardian.com/world/2020/mar/04/coronavirus-google-tech-dublin-twitter-work-from-home#maincontent) | Limited / Geo-specific | Restricted | ? | ? | 2020-03-03 |
 | [Indeed](https://www.kvue.com/article/news/health/indeed-coronavirus-work-from-home/269-79c7797f-4d60-41df-bd9b-8b6bc25d9f3f) | Enforced | Restricted | Restricted | Restricted | 2020-03-04 |
 | Lyft | Encouraged | ? | ? | ? | 2020-03-04 | 


### PR DESCRIPTION
Got an update through internal channels that employees in King County, Washington and the SF Bay Area are recommended to work from home