### PR TITLE
Add notes about IBM restricting travel and Think 2020

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 | [Fastly](https://www.fastly.com/blog/exercising-caution-as-covid-19-evolves) | Required | Restricted | Restricted | Restricted | 2020-03-01 |
 | GitHub | Encouraged | Restricted | ? | ? | 2020-03-04 |
 | [Google](https://www.theguardian.com/world/2020/mar/04/coronavirus-google-tech-dublin-twitter-work-from-home#maincontent) | Limited / Geo-specific | Restricted | ? | ? | 2020-03-03 |
+| [IBM](https://www.theverge.com/2020/3/4/21165449/ibm-coronavirus-suspending-domestic-international-travel) | ? | Restricted | ? | ? | 2020-03-05 |
 | [Indeed](https://www.kvue.com/article/news/health/indeed-coronavirus-work-from-home/269-79c7797f-4d60-41df-bd9b-8b6bc25d9f3f) | Required | Restricted | Restricted | Restricted | 2020-03-04 |
 | Lyft | Encouraged | ? | ? | ? | 2020-03-04 | 
 | [Microsoft](https://www.theverge.com/2020/3/4/21164522/microsoft-coronavirus-response-comment-employees-memo-work-from-home) | Limited / Geo-specific | ? | ? | ? | 2020-03-03 |
@@ -46,6 +47,7 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 - [Google Cloud Next](https://cloud.withgoogle.com/next/sf/): online-only
 - [Google I/O](https://events.google.com/io/): online-only
 - [Google Tensoflow Dev Summit](https://www.tensorflow.org/dev-summit/): online-only
+- [IBM Think 2020](https://www.ibm.com/events/think/): online-only
 - [Internet Freedom Summit](https://internetfreedomfestival.org/wiki/index.php/Cancellation_of_the_2020_Internet_Freedom_Festival): cancelled
 - [KubeCon EU 2020](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/attend/novel-coronavirus-update/): postponed until July/August, 2020, dates pending
 - [Lesbians Who Tech](https://twitter.com/ArlanWasHere/status/1234622619867066368?s=20): "postponed until August 6-8, 2020 pending developments"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the running list of what in tech has been affected by COVID-19. Pull requests gratefully accepted, especially around design or data formatting or correctness.
 
-## Companies - 19
+## Companies - 20
 
 | Company | WFH | Travel | Visitors | Events | Last Update |
 | --- | --- | --- | --- | --- | --- | 
@@ -28,7 +28,7 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 | [Twitter](https://blog.twitter.com/en_us/topics/company/2020/keeping-our-employees-and-partners-safe-during-coronavirus.html) | Required | Restricted | Restricted | Restricted | 2020-03-03 |
 | Yelp | Encouraged | Restricted | ? | ? | 2020-03-03 |
 
-## Events - 35
+## Events - 36
 
 - [APIdays Singapore](https://www.apidays.co/singapore): Postponed until August 19-20
 - [AWS Summit Paris](https://aws.amazon.com/fr/events/summits/paris/): cancelled


### PR DESCRIPTION
IBM is halting all domestic travel and restricting international travel through the end of March and turning Think 2020 (first week of May) into a digital-only event.