### PR TITLE
Add named anchors for companies and events

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 This is the running list of what in tech has been affected by COVID-19. Pull requests gratefully accepted, especially around design or data formatting or correctness.
 
+<a name="companies"></a>
 ## Companies - 21
 
 | Company | WFH | Travel | Visitors | Events | Last Update |
@@ -31,6 +32,7 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 | [Typless](https://typless.com/2020/03/05/switching-to-fully-remote-work/) | Required | Restricted | Restricted | Restricted | 2020-03-04 |
 | Yelp | Encouraged | Restricted | ? | ? | 2020-03-03 |
 
+<a name="events"></a>
 ## Events - 42
 
 - [APIdays Singapore](https://www.apidays.co/singapore): Postponed until August 19-20


### PR DESCRIPTION
When the counts change, the headings change, which in results in the autogenerated anchors changing. This makes it impossible to have a static shareable link.