### PR TITLE
Added RLCS Season 9 World Championship cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 | Yelp | Encouraged | Restricted | ? | ? | 2020-03-03 |
 
 <a name="events"></a>
-## Events - 58
+## Events - 59
 
 - [APIdays Singapore](https://www.apidays.co/singapore): Postponed until August 19-20
 - [Atlassian Summit](https://www.atlassian.com/company/events/summit): Moving to virtual.
@@ -89,6 +89,7 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 - [Oracle User Group Irelend (OUG Ireland)](https://twitter.com/MDWidlake/status/1234864869377216515): cancelled
 - [PyCon Italia](https://pycon.it/en/blog/pycon-11-postponed-to-november): moved to November
 - [Red Hat Summit](https://www.redhat.com/en/summit): Moving to virtual event.
+- [Rocket League World Championship](https://www.rocketleague.com/news/important-rocket-league-esports-update/): cancelled
 - [RubyKaigi](https://rubykaigi.org/2020): postponed until September
 - [SNUG Silicon Valley](https://www.synopsys.com/community/snug/snug-silicon-valley.html): cancelled
 - [Security Analyst Summit](https://twitter.com/TheSAScon/status/1234911915773583361): cancelled


### PR DESCRIPTION
Psyonix announced on [their blog](https://www.rocketleague.com/news/important-rocket-league-esports-update/) that the World Championship for RLCS Season 9 has ben cancelled.  They are still evaluating exactly how they will finish out the season, but the in-person event in Texas (USA) has been cancelled.