### PR TITLE
Minecraft Festival postponed to 2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 | Yelp | Encouraged | Restricted | ? | ? | 2020-03-03 |
 
 <a name="events"></a>
-## Events - 58
+## Events - 60
 
 - [APIdays Singapore](https://www.apidays.co/singapore): Postponed until August 19-20
 - [Atlassian Summit](https://www.atlassian.com/company/events/summit): Moving to virtual.
@@ -82,6 +82,7 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 - [Microsoft Ignite the Tour Singapore](https://www.microsoft.com/en-sg/ignite-the-tour/singapore): cancelled
 - [Microsoft Ignite the Tour Zurich](https://www.microsoft.com/de-ch/ignite-the-tour/zurich): cancelled
 - [Microsoft MVP Summit](https://www.geekwire.com/2020/microsoft-cancels-mvp-summit-due-coronavirus-outbreak-seattle-area/): cancelled
+- [Minecraft Festival](https://www.minecraft.net/en-us/article/minecraft-festival-postponed): postponed to 2021, Minecraft Live still happening online-only
 - [Mobile World Congress](https://www.mwcbarcelona.com/gsma-statement-on-mwc-2020/): cancelled
 - [NVidia GPU Conference](https://www.theverge.com/2020/3/2/21161635/nvidias-gpu-technology-conference-gtc-online-only-coronavirus): online-only
 - [Open Compute Project Global Summit](https://www.opencompute.org/blog/we-are-moving-the-2020-ocp-global-summit-to-an-interactive-virtual-global-summit): Changed to a virtual event.


### PR DESCRIPTION
The digital portion, Minecraft Live, is still happening