### PR TITLE
Fixed VSCO's WFH column

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 | [Textio](https://www.seattletimes.com/business/some-seattle-tech-companies-tell-employees-to-work-from-home-to-slow-spread-of-coronavirus/) | Encouraged | ? | ? | ? | 2020-03-04 |
 | [Twitter](https://blog.twitter.com/en_us/topics/company/2020/keeping-our-employees-and-partners-safe-during-coronavirus.html) | Required | Restricted | Restricted | Restricted | 2020-03-03 |
 | [Typless](https://typless.com/2020/03/05/switching-to-fully-remote-work/) | Required | Restricted | Restricted | Restricted | 2020-03-04 |
-| VSCO | Restricted | Restricted | ? | ? | 2020-03-06 |
+| VSCO | Required | Restricted | ? | ? | 2020-03-06 |
 | Yelp | Encouraged | Restricted | ? | ? | 2020-03-03 |
 
 <a name="events"></a>


### PR DESCRIPTION
I used the wrong word usage for the `WFH` column. whoops. ty for pointing this out @UsmannK