### PR TITLE
update Crunchbase to "Encouraged"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 | Cloudflare | ? | Restricted | Restricted | Restricted | 2020-03-04 |
 | [Coinbase](https://docs.google.com/document/d/1SRP4dnVCvKB7A5WXrESe-cL51i6_cg5nNGLNld6qch0/edit) | Encouraged | ? | ? | ? | 2020-03-03 |
 | Contentful | Encouraged | Restricted | ? | Restricted | 2020-03-03 |
-| Crunchbase | Required | Restricted | Restricted | ? | 2020-03-05 |
+| Crunchbase | Encouraged | Restricted | Restricted | Restricted | 2020-03-06 |
 | Crunchyroll | Encouraged | Restricted | Restricted | Restricted | 2020-03-05 |
 | Digit | Required | Restricted | Restricted | Restricted | 2020-03-05 |
 | Determined AI | Encouraged | Restricted | Restricted | Restricted | 2020-03-06 |


### PR DESCRIPTION
Crunchbase is not requiring WFH - our policy is that WFH is "strongly encouraged"

Source: am Head of Engineering at Crunchbase.