### PR TITLE
Add Wikimedia Foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is the running list of what in tech has been affected by COVID-19. Pull requests gratefully accepted, especially around design or data formatting or correctness.
 
 <a name="companies"></a>
-## Companies - 45
+## Companies - 46
 
 | Company | WFH | Travel | Visitors | Events | Last Update |
 | --- | --- | --- | --- | --- | --- | 
@@ -52,6 +52,7 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 | [Twitter](https://blog.twitter.com/en_us/topics/company/2020/keeping-our-employees-and-partners-safe-during-coronavirus.html) | Required | Restricted | Restricted | Restricted | 2020-03-03 |
 | [Typless](https://typless.com/2020/03/05/switching-to-fully-remote-work/) | Required | Restricted | Restricted | Restricted | 2020-03-04 |
 | VSCO | Required | Restricted | ? | ? | 2020-03-06 |
+| [Wikimedia Foundation](https://wikimediafoundation.org/news/2020/03/06/wikimedia-foundation-will-close-san-francisco-office-and-encourage-remote-work-for-march-2020-amidst-covid-19-concerns/) | Encouraged, required for San Francisco office | Restricted | Restricted | Restricted | 2020-03-06 |
 | Yelp | Encouraged | Restricted | ? | ? | 2020-03-03 |
 
 <a name="events"></a>


### PR DESCRIPTION
From the announcement: "For the remainder of March 2020, our San Francisco office will be closed to staff and visitors. We are putting in place measures to ensure that our San Francisco-based staff have resources and support to continue working remotely. Our Washington D.C. office will remain open for the time being, though we are encouraging everyone to take precautions to protect themselves and their communities and to work remotely where possible.

We have also temporarily suspended nonessential travel for all staff, and instituted a risk review process for any travel considered essential. In addition, we have been in touch with members of the Wikimedia movement community with respect to upcoming events and are taking necessary steps to cancel or postpone these, based on potential risks."