### PR TITLE
Update Amazon wfh policy for Bay Area employees

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 
 | Company | WFH | Travel | Visitors | Events | Last Update |
 | --- | --- | --- | --- | --- | --- | 
-| [Amazon](https://www.businessinsider.com/companies-asking-employees-to-work-from-home-due-to-coronavirus-2020) | Encouraged, Recommended for Seattle to 3/31 | Restricted | Restricted | Restricted | 2020-03-04 |
+| [Amazon](https://www.businessinsider.com/companies-asking-employees-to-work-from-home-due-to-coronavirus-2020) | Encouraged, Recommended for Seattle and Bay Area to 3/31 | Restricted | Restricted | Restricted | 2020-03-06 |
 | Apple | Encouraged | Restricted | ? | ? | 2020-03-06 |
 | [Adobe](https://www.npr.org/2020/03/03/811728989/coronavirus-cancellations-and-travel-bans-google-is-latest) | ? | Restricted | ? | ? | 2020-03-06 |
 | Brex | Encouraged, Recommended for San Francisco, Vancouver, New York and Salt Lake City offices | Restricted | Restricted | Restricted | 2020-03-06 |


### PR DESCRIPTION
Add Bay Area Amazonians for the WFH recommendation list (3/6)