### PR TITLE
JP Morgan

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 | [IBM](https://www.theverge.com/2020/3/4/21165449/ibm-coronavirus-suspending-domestic-international-travel) | ? | Restricted | ? | ? | 2020-03-05 |
 | [Indeed](https://www.kvue.com/article/news/health/indeed-coronavirus-work-from-home/269-79c7797f-4d60-41df-bd9b-8b6bc25d9f3f) | Required | Restricted | Restricted | Restricted | 2020-03-04 |
 | Joy | Encouraged | ? | ? | ? | 2020-03-06 |
+| J.P. Morgan | Encouraged | Restricted | ? | ? | 2020-03-06 |
 | Lyft | Encouraged | Non-critical restricted | ? | ? | 2020-03-06 | 
 | [LinkedIn](https://www.businessinsider.com/linkedin-tells-employees-to-work-from-home-over-coronavirus-concerns-2020-3) | Encouraged | ? | ? | ? | 2020-03-05 |
 | [Microsoft](https://www.theverge.com/2020/3/4/21164522/microsoft-coronavirus-response-comment-employees-memo-work-from-home) | Limited / Geo-specific | ? | ? | ? | 2020-03-03 |


### PR DESCRIPTION
JPMorgan announced a pilot program, code-named “Project Kennedy,” which calls for 10% of the company’s 125,000 plus employees to work from home.

https://www.forbes.com/sites/jackkelly/2020/03/04/jpmorgan-asked-thousands-of-employees-to-work-from-home-this-may-start-a-new-trend/amp/


Investment bank JPMorgan has banned all "non essential" domestic travel in an effort to shore up its defences against a coronavirus pandemic.

https://www.afr.com/street-talk/jpmorgan-travel-ban-widened-to-include-domestic-trips-20200306-p547fk