### PR TITLE
Correcting info on Shopify conferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 | [Zillow](https://www.zillow.com/) | Encouraged | Restricted | ? | ? | 2020-03-06 |
 
 <a name="events"></a>
-## Events - 81
+## Events - 82
 
 - [Apache Roadshow/DC](https://blogs.apache.org/foundation/entry/notice-on-apache-2020-conferences): cancelled
 - [APIdays Singapore](https://www.apidays.co/singapore): Postponed until August 19-20

--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 - [SAP Concur Fusion](https://fusion.concur.com/fusion-orlando-announcement): in-person canceled; online-only event
 - [SNUG Silicon Valley](https://www.synopsys.com/community/snug/snug-silicon-valley.html): cancelled
 - [Security Analyst Summit](https://twitter.com/TheSAScon/status/1234911915773583361): cancelled
-- [Shopify Unite & Shopify Pursuit](https://www.shopify.com.au/partners/blog/unite-2020-update): cancelled
+- [Shopify Unite](https://www.shopify.com.au/partners/blog/unite-2020-update): moving to virtual event
+- [Shopify Pursuit (Melbourne and Mexico)](https://pursuit.shopify.com/): postponed, no date given
 - [Shoptalk](https://www.retaildive.com/news/shoptalk-postponed-until-september-on-coronavirus-concerns/573549/): Postponed until September
 - [SXSW](https://www.sxsw.com/2020-event-update/): cancelled
 - [SRECon Americas West](https://www.usenix.org/conferences/coronavirus): postponed until June


### PR DESCRIPTION
Official websites say that Pursuit will be rescheduled, no date given; and that the "in-person portion" of Unite is canceled; virtual events TBD.