### PR TITLE
Added STPCon

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 | Zulily | Encouraged | Restricted | Restricted | ? | 2020-03-07 |
 
 <a name="events"></a>
-## Events - 92
+## Events - 93
 
 - [Apache Roadshow/DC](https://blogs.apache.org/foundation/entry/notice-on-apache-2020-conferences): cancelled
 - [APIdays Singapore](https://www.apidays.co/singapore): postponed until August 19-20
@@ -157,6 +157,7 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 - [Shopify Unite](https://www.shopify.com.au/partners/blog/unite-2020-update): moving to virtual event
 - [Shopify Pursuit (Melbourne and Mexico)](https://pursuit.shopify.com/): postponed, no date given
 - [Shoptalk](https://www.retaildive.com/news/shoptalk-postponed-until-september-on-coronavirus-concerns/573549/): Postponed until September
+- [STP Con](https://www.stpcon.com/important-stpcon-spring-2020-announcement-please-read/): cancelled
 - [SXSW](https://www.sxsw.com/2020-event-update/): cancelled
 - [SRECon Americas West](https://www.usenix.org/conferences/coronavirus): postponed until June
 - [Strata Data & AI](https://conferences.oreilly.com/strata-data-ai/stai-ca): merged with NY in September


### PR DESCRIPTION
Adds the following events or companies:
 - STP Con (Software Test Professionals Conference)

### Checklist

 - [x] I have updated the event or company counts
 - [n/a] I have put the most recent relevant date in the "Last Update" column
 - [x] I have linked to the article about the change, not the company's website
