### PR TITLE
Added 9 events, fixed or added more info of others

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,26 +79,28 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 | Zulily | Encouraged | Restricted | Restricted | ? | 2020-03-07 |
 
 <a name="events"></a>
-## Events - 94
+## Events - 103
 
 - [Apache Roadshow/DC](https://blogs.apache.org/foundation/entry/notice-on-apache-2020-conferences): cancelled
 - [APIdays Singapore](https://www.apidays.co/singapore): postponed until August 19-20
 - [Architectural Support for Programming Languages and Operating Systems (ASPLOS)](https://asplos-conference.org/): cancelled
 - [Atlassian Summit](https://www.atlassian.com/company/events/summit): moving to virtual
-- [Area41 Security Conference](https://a41con.blogspot.com/2020/03/area41-postponed-to-june-2021.html): postponed
+- [Area41 Security Conference](https://a41con.blogspot.com/2020/03/area41-postponed-to-june-2021.html): postponed until June 2021
 - [Aruba Atmosphere 2020](https://www.atlassian.com/company/events/summit): virtual with small local events
 - [AWS Summit Paris](https://aws.amazon.com/fr/events/summits/paris/): cancelled
 - [AWS Summit Sydney](https://aws.amazon.com/events/summits/sydney/): cancelled
 - [Adobe Summit & Magento Imagine](https://www.adobe.com/summit.html): online-only
 - [Berlin March Golang Meetup](https://www.meetup.com/golang-users-berlin/events/265472557): online-only
-- [Black Hat Asia](https://www.blackhat.com/asia-20/travel-updates.html): postponed until fall
+- [Black Hat Asia](https://www.blackhat.com/asia-20/travel-updates.html): postponed until September 29 - October 2
+- [BountyCon](https://www.facebook.com/notes/facebook-bug-bounty/an-update-on-bountycon/3278348118846058/): postponed
+- [BSides Charm](https://www.bsidescharm.org/health/): optional remote speaker options, no international speakers but event will happen
 - [BSides Liverpool](https://twitter.com/BsidesLivrpool/status/1235988839623266304): postponed until later this year
 - [California Association for Behavior Analysis Conference](https://calaba.org/conference): cancelled
 - [Cisco Live Melbourne](https://www.ciscolive.com/apjc.html): cancelled
 - [CloudFest 2020](https://www.cloudfest.com/): cancelled
 - [Collision](https://collisionconf.com/): moving to virtual event
 - [Deconstruct](https://www.deconstructconf.com/): cancelled
-- [DEFCON China 2.0](https://defcon.org/html/defcon-china-2/dc-cn-2-index.html): postponed
+- [DEFCON China 2.0](https://defcon.org/html/defcon-china-2/dc-cn-2-index.html): postponed, new date TBD
 - [DevNet Create](https://developer.cisco.com/devnetcreate/2020/): postponed, new date unknown
 - [DevOpsDays Seattle](https://twitter.com/DevOpsDaysSEA/status/1235307914908389376): postponed, possibly cancelled
 - [DevOpsDays Tokyo](https://twitter.com/DevOpsDaysTokyo/status/1234433425114722308): cancelled
@@ -115,6 +117,9 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 - [F5 Agility](https://www.f5.com/agility): moving to virtual event
 - [Facebook Global Marketing Summit](https://www.businessinsider.com/how-facebook-affected-novel-coronavirus-outbreak-2020-2): cancelled
 - [Facebook F8](https://developers.facebook.com/blog/post/2020/02/27/important-f8-2020-update/): moving to a primarily online event
+- [Fast Software Encryption (FSE) 2020](https://fse.iacr.org/2020/): postponed
+- [FIRST Cyber Threat Intelligence Symposium 2020 (FIRST CTI)](https://www.first.org/events/symposium/zurich2020/): cancelled
+- [FIRST Technical Colloquium 2020 (FIRST TC)](https://www.first.org/events/colloquia/amsterdam2020/): postponed until next year (2021)
 - [Flink Forward (Apache Flink)](https://www.flink-forward.org/sf-2020): cancelled, considering moving to virtual
 - [Game Developers Conference (GDC)](https://www.gdconf.com/news/important-gdc-2020-update): postponed
 - [GitHub Satellite](https://githubsatellite.com/): going online-only
@@ -125,9 +130,11 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 - [IBM Think 2020](https://www.ibm.com/events/think/): online-only
 - [ICANN 67](https://www.icann.org/news/announcement-2020-02-19-en): online-only
 - [Ingram Micro Cloud Summit 2020](https://www.ingrammicrocloud.com/press-releases/ingram-micro-cloud-postpones-cloud-summit-2020-early-2021/): postponed until early 2021
-- [Internet Freedom Summit](https://internetfreedomfestival.org/wiki/index.php/Cancellation_of_the_2020_Internet_Freedom_Festival): cancelled
+- [IsomniHack 2020](hhttps://insomnihack.ch/covid-19/): postponed until June
+- [Internet Freedom Festival](https://internetfreedomfestival.org/wiki/index.php/Cancellation_of_the_2020_Internet_Freedom_Festival): cancelled
 - [Internet2 2020 Global Summit](https://meetings.internet2.edu/2020-global-summit/update-coronavirus/): cancelled
-- [Kaspersky's Security Analyst Summit](https://thesascon.com/): postponed until Fall
+- [ISC West](https://www.iscwest.com/RNA/RNA_ISCWest_v2/2020/doc/legal/ISC-West-A-Statement-from-Reed-Exhibitions-3-6.pdf): postponed until July, dates TBD
+- [Kaspersky's Security Analyst Summit](https://thesascon.com/): postponed until September, exact date TBD
 - [KubeCon EU 2020](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/attend/novel-coronavirus-update/): postponed until July/August, 2020, dates pending
 - [Linaro Connect Budapest 2020](https://www.linaro.org/blog/linaro-connect-budapest-2020-cancelled/): cancelled
 - [Lesbians Who Tech](https://twitter.com/ArlanWasHere/status/1234622619867066368?s=20): postponed until August 6-8, 2020 pending developments
@@ -145,10 +152,12 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 - [Oracle User Group Irelend (OUG Ireland)](https://twitter.com/MDWidlake/status/1234864869377216515): cancelled
 - [Outreach Unleash 2020](https://www.outreach.io/blog/unleash-20-update): cancelled
 - [Paris Blockchain Week Summit](https://www.pbwsummit.com/): postponed until Dec. 9-10
+- [Pwn2Own CansSecWest](https://www.thezdi.com/blog/2020/3/3/announcing-remote-participation-in-pwn2own-vancouver): optional remote participation (can attend, or have people on site execute commands/actions ie. on-site not required to participate)
 - [PyCon Italia](https://pycon.it/en/blog/pycon-11-postponed-to-november): moved to November
 - [PyCon SK](https://2020.pycon.sk/en/news.html): moved to September
 - [Qualtrics X4 Summit](https://www.qualtrics.com/x4summit/): postponed to early Fall 2020
-- [Red Hat Summit](https://www.redhat.com/en/summit): moving to virtual event.
+- [Red Hat Summit](https://www.redhat.com/en/summit): moving to virtual event
+- [Red Team Summit](https://www.zdnet.com/article/a-list-of-security-conferences-canceled-or-postponed-due-to-coronavirus-concerns/): postponed until June 11-12
 - [RedisConf20](https://events.redislabs.com/redisconf20/): moving to virtual event
 - [RubyKaigi](https://rubykaigi.org/2020): postponed until September
 - [SaaStr Annual](https://www.saastrannual.com/): postponed until September


### PR DESCRIPTION
Events primarily pulled from Issue #162 which was a link to a compendium of events in the information security / cyber security part of tech.

Adds the following events or companies:
- Added FIRST CTI
- Added Red Team Summit
- Fixed period on event
- Added ISC West
- Added pwn2own
- Added Insomnihack
- Added FSE
- Updated BlackHat Asia dates
- Added BSides Charm
- Added Bountycon
- Added FIRST TC
- Updated Kaspersky's postponement date
- Corrected name of Internet Freedom Festival 
- Updated Area41 postponement date
- Updated # of events

### Checklist

 - [x] I have updated the event or company counts
 - [n/a] I have put the most recent relevant date in the "Last Update" column
 - [x] I have linked to the article about the change, not the company's website