### PR TITLE
Fix NASA Ames link

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 | Lyft | Encouraged | Non-critical restricted | ? | ? | 2020-03-06 |
 | Microsoft[[1]](https://www.theverge.com/2020/3/4/21164522/microsoft-coronavirus-response-comment-employees-memo-work-from-home) | Limited / Geo-specific | ? | ? | ? | 2020-03-03 |
 | Mozilla | Encouraged | Restricted | ? | ? | 2020-03-06 |
-| [NASA Ames][[1]](https://twitter.com/scottbudman/status/1237054027201794049) | Required | ? | ? | ? | 2020-03-09 |
+| NASA Ames[[1]](https://twitter.com/scottbudman/status/1237054027201794049) | Required | ? | ? | ? | 2020-03-09 |
 | NetApp | ? | Restricted | ? | ? | 2020-03-09 |
 | Nordstrom[[1]](https://www.geekwire.com/2020/coronavirus-live-updates-seattle-tech-community-grappling-covid-19/) | Encouraged | Restricted | Restricted | Restricted | 2020-03-04 |
 | OfferUp | Encouraged | Restricted | Restricted | Restricted | 2020-03-06 |


### PR DESCRIPTION
Remove `[` and `]`

Corrects the following events or companies:
 - NASA Ames

### Checklist

 - [n/a] I have updated the event or company counts
 - [n/a] I have put the most recent relevant date in the "Last Update" column
 - [n/a] I have linked to the article about the change, not the company's website
