### PR TITLE
Add LibrePlanet 2020

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 - [Kaspersky's Security Analyst Summit](https://thesascon.com/): postponed until September, exact date TBD
 - [KubeCon EU 2020](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/attend/novel-coronavirus-update/): postponed until July/August, 2020, dates pending
 - [Lesbians Who Tech](https://twitter.com/ArlanWasHere/status/1234622619867066368?s=20): postponed until August 6-8, 2020 pending developments
+- [LibrePlanet 2020](https://www.fsf.org/blogs/community/libreplanet-2020-in-person-component-canceled-but-well-see-you-online): online-only
 - [Linaro Connect Budapest 2020](https://www.linaro.org/blog/linaro-connect-budapest-2020-cancelled/): cancelled
 - [Microsoft Ignite the Tour Amsterdam](https://www.microsoft.com/nl-nl/ignite-the-tour/amsterdam): cancellation announced March 2, 2020
 - [Microsoft Ignite the Tour Singapore](https://www.microsoft.com/en-sg/ignite-the-tour/singapore): cancelled


### PR DESCRIPTION
Adds the following events or companies:
 - LibrePlanet 2020 https://github.com/phildini/stayinghomeclub/issues/206

### Checklist

 - [X] I have updated the event or company counts
 - [X] I have put the most recent relevant date in the "Last Update" column
 - [X] I have linked to the article about the change, not the company's website
