### PR TITLE
Add Pinterest WFH info

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 | Pandora | Optional | Restricted | Restricted | ? | 2020-03-09 |
 | Parler | Required | Restricted | Restricted | Restricted | 2020-03-06 |
 | PingCap | Required for Bay Area | Restricted | Restricted | Restricted | 2020-03-07 |
+| Pinterest | Encouraged | Restricted | Restricted | Partially Restricted | 2020-03-08 |
 | PressCentric | Encouraged | Restricted | ? | ? | 2020-03-06 |
 | ProdPerfect | Encouraged | Restricted | Restricted | Restricted | 2020-03-06 |
 | Redfin[[1]](https://www.seattletimes.com/business/some-seattle-tech-companies-tell-employees-to-work-from-home-to-slow-spread-of-coronavirus/) | Encouraged | ? | ? | ? | 2020-03-04 |


### PR DESCRIPTION
Adds the following events or companies:
 - Pinterest
 -

### Checklist

 - [X] I have updated the event or company counts
 - [X] I have put the most recent relevant date in the "Last Update" column
 - [] I have linked to the article about the change, not the company's website
