### PR TITLE
Write the Docs Portland delayed, likely to August

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 | Zulily | Encouraged | Restricted | Restricted | ? | 2020-03-07 |
 
 <a name="events"></a>
-## Events - 113
+## Events - 114
 
 - [Adobe Summit & Magento Imagine](https://www.adobe.com/summit.html): online-only
 - [Apache Roadshow/Chicago](https://blogs.apache.org/foundation/entry/notice-on-apache-2020-conferences): cancelled
@@ -224,6 +224,7 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 - [TSConf EU](https://twitter.com/tsconfeu/status/1235135186033139713): postponed
 - [TwitchCon Amsterdam](https://twitter.com/TwitchCon/status/1235942102556651521?s=20): cancelled
 - [Unreal Fest Europe](https://www.unrealengine.com/en-US/events/unreal-fest-europe-2020): cancelled
+- [Write the Docs Portland 2020](https://www.writethedocs.org/conf/portland/2020/news/covid-19-update-02/): postponed, likely to August; final date expected to be announced by March 20
 - [Women in Cybersecurity (WiCyS) 2020](https://www.wicys.org/): cancelled, looking for alternative options TBD
 - [WSLConf](https://www.wslconf.dev/): going online-only
 - [WWCode CONNECT India 2020](https://www.womenwhocode.com/blog/coronavirus-update-a-note-from-our-ceo): postponed


### PR DESCRIPTION
Adds the following events or companies:
 - Write the Docs Portland

H/T @williln on Twitter

### Checklist

 - [*] I have updated the event or company counts
 - [N/A] I have put the most recent relevant date in the "Last Update" column
 - [*] I have linked to the article about the change, not the company's website
