### PR TITLE
Add Indigo Agriculture in Boston and Memphis

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is the running list of what in tech has been affected by COVID-19. Pull requests gratefully accepted, especially around design or data formatting or correctness.
 
 <a name="companies"></a>
-## Companies - 128
+## Companies - 130
 
 | Company | WFH | Travel | Visitors | Events | Last Update |
 | --- | --- | --- | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 | Humu | Encouraged, recent travel Required | Restricted | Discouraged | ? | 2020-03-02 |
 | IBM[[1]](https://www.theverge.com/2020/3/4/21165449/ibm-coronavirus-suspending-domestic-international-travel) | ? | Restricted | ? | ? | 2020-03-05 |
 | Indeed[[1]](https://www.kvue.com/article/news/health/indeed-coronavirus-work-from-home/269-79c7797f-4d60-41df-bd9b-8b6bc25d9f3f) | Required | Restricted | Restricted | Restricted | 2020-03-04 |
+| Indigo Agriculture | Required | Restricted | Restricted | Restricted | 2020-03-11 |
 | Intel | Encouraged | Restricted | Screened | Restricted | 2020-03-09 |
 | Internet Archive [[1]](https://twitter.com/brewster_kahle/status/1237194160949489670) | Required | ? | ? | ? | 2020-03-10 |
 | Intuit | Encouraged | Restricted | Restricted | Restricted | 2020-03-06 |


### PR DESCRIPTION
Adds the following events or companies:
 - Indigo Agriculture in both Boston and Memphis (internal communication)

### Checklist

- [x]  I have updated the event or company counts
- [x]  I have put the most recent relevant date in the "Last Update" column
- [ ]  ~I have linked to the article about the change, not the company's website~ Internal communications only so far.
