### PR TITLE
Notion WFH is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ This is the running list of what in tech has been affected by COVID-19. Pull req
 | Nextdoor | Encouraged | ? | ? | ? | 2020-03-09 |
 | Niteo | Required | Restricted | Restricted | Restricted | 2020-03-11 |
 | Nordstrom[[1]](https://www.geekwire.com/2020/coronavirus-live-updates-seattle-tech-community-grappling-covid-19/) | Encouraged | Restricted | Restricted | Restricted | 2020-03-04 |
-| Notion Labs | Encouraged | Restricted | Restricted | Restricted | 2020-03-11 |
+| Notion Labs | Required | Restricted | Restricted | Restricted | 2020-03-11 |
 | Ocado | Allowed | Restricted | ? | ? | 2020-03-11 |
 | Oden Technologies | Encouraged | Restricted | Restricted | Restricted | 2020-03-10 |
 | OLX Group | Encouraged | Restricted | ? | Restricted | 2020-03-11 |


### PR DESCRIPTION
Updates the following events or companies:
 - Notion Labs

### Checklist

 - [x] I have updated the event or company counts
 - [x] I have put the most recent relevant date in the "Last Update" column
 - [ ] I have linked to the article about the change, not the company's website

This morning we were "encouraged" to WFH; as of a few hours ago it was changed to "required".