### PR TITLE
Culture Amp requiring WFH for all, 16/Mar/2020.

### DIFF
--- a/_data/companies.yml
+++ b/_data/companies.yml
@@ -251,11 +251,11 @@
   last_update: 2020-03-05 
  
 - name: Culture Amp 
-  wfh: Encouraged 
+  wfh: Restricted
   travel: Restricted 
   visitors: Restricted 
   events: Restricted 
-  last_update: 2020-03-10 
+  last_update: 2020-03-12
  
 - name: Dell-EMC 
   wfh: Allowed 

--- a/_data/companies.yml
+++ b/_data/companies.yml
@@ -286,7 +286,7 @@
   last_update: 2020-03-05
 
 - name: Culture Amp
-  wfh: Restricted
+  wfh: Required
   travel: Restricted
   visitors: Restricted
   events: Restricted


### PR DESCRIPTION
Modifies the following events or companies:
 - Culture Amp

WFH required starting 16/Mar/2020 inclusive.  Announced Thu Mar 12 15:38 AEDT 2020.

### Checklist

 - [x] (N/A) I have updated the event or company counts
 - [x] I have put the most recent relevant date in the "Last Update" column
 - [ ] (announcement was on internal Slack) I have linked to the article about the change, not the company's website
