### PR TITLE
Added Kentico & events

### DIFF
--- a/_data/companies.yml
+++ b/_data/companies.yml
@@ -586,7 +586,7 @@
   events: "?" 
   last_update: 2020-03-11 
  
-- name: Kentico 
+- name: Kentico[[1]](https://www.kentico.com/blog/how-kentico-is-coping-with-covid-19) 
   wfh: Required 
   travel: Restricted 
   visitors: Restricted

--- a/_data/companies.yml
+++ b/_data/companies.yml
@@ -586,6 +586,13 @@
   events: "?" 
   last_update: 2020-03-11 
  
+- name: Kentico 
+  wfh: Required 
+  travel: Restricted 
+  visitors: Restricted
+  events: Restricted
+  last_update: 2020-03-12
+ 
 - name: Lightstep 
   wfh: Encouraged 
   travel: Restricted 

--- a/_data/companies.yml
+++ b/_data/companies.yml
@@ -670,7 +670,7 @@
   events: "?"
   last_update: 2020-03-11
 
-- name: Kentico[[1]](https://www.kentico.com/blog/how-kentico-is-coping-with-covid-19) 
+- name: "Kentico[[1]](https://www.kentico.com/blog/how-kentico-is-coping-with-covid-19)"
   wfh: Required 
   travel: Restricted 
   visitors: Restricted

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -201,6 +201,9 @@
 
 - name: "[KubeCon EU 2020](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/attend/novel-coronavirus-update/)"
   status: postponed until July/August, 2020, dates pending
+  
+- name: "[Kentico Partner Summit Q2 2020](https://www.eventbrite.com/e/q2-2020-kentico-partner-summit-tickets-91103997509)"
+  status: postponed until later this year
 
 - name: "[Lesbians Who Tech](https://twitter.com/ArlanWasHere/status/1234622619867066368?s=20)"
   status: postponed until August 6-8, 2020 pending developments


### PR DESCRIPTION
https://www.kentico.com/blog/how-kentico-is-coping-with-covid-19

starting today, we require a majority of employees to WFH (the whole main office)

Adds the following events or companies:
 - Kentico
 - Kentico Partner Summit

### Checklist

 - [x] I have updated the event or company counts
 - [x] I have put the most recent relevant date in the "Last Update" column
 - [x] I have linked to the article about the change, not the company's website
