### PR TITLE
Add company and political event, small fix to another event

### DIFF
--- a/_data/companies.yml
+++ b/_data/companies.yml
@@ -950,6 +950,13 @@
   events: Restricted
   last_update: 2020-03-08
 
+- name: RumbleUp[[1]](https://medium.com/rumbleup/covid-19-why-texting-is-the-new-handshake-5cfb2e30a23)
+  wfh: Required
+  travel: Restricted
+  visitors: Restricted
+  events: Restricted
+  last_update: 2020-03-12
+
 - name: Salesforce[[1]](https://www.salesforce.com/blog/2020/03/safety-and-wellbeing-those-around-you.html)
   wfh: Encouraged
   travel: Restricted

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -44,7 +44,7 @@
   status: postponed to Q3
 
 - name: "[Black Hat Asia](https://www.blackhat.com/asia-20/travel-updates.html)"
-  status: postponed until September 29 - Octobe"r 2"
+  status: postponed until September 29 - October 2
 
 - name: "[BountyCon](https://www.facebook.com/notes/facebook-bug-bounty/an-update-on-bountycon/3278348118846058/)"
   status: postponed
@@ -57,6 +57,9 @@
 
 - name: "[California Association for Behavior Analysis Conference](https://calaba.org/conference)"
   status: cancelled
+
+- name: "[CampaignTech East](https://campaigntecheast.com/)"
+  status: postponed until June 25-26
 
 - name: "[Cisco Live Melbourne](https://www.ciscolive.com/apjc.html)"
   status: cancelled


### PR DESCRIPTION
Adds the following events or companies:
 - RumbleUp (company)
 - CampaignTech East (event)

### Checklist

 - [X] I have updated the event or company counts _(updates automatically now, I believe)_
 - [X] I have put the most recent relevant date in the "Last Update" column
 - [X] I have linked to the article about the change, not the company's website
