### PR TITLE
Added Adobe ColdFusion Summit East 2020 to events

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -1,6 +1,6 @@
 - name: "[Adobe Summit & Magento Imagine](https://www.adobe.com/summit.html)"
   status: online-only
-  
+
 - name: "[Adobe ColdFusion Summit East 2020](https://carahevents.carahsoft.com/CFSummit2020/)"
   status: cancelled
   

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -1,6 +1,9 @@
 - name: "[Adobe Summit & Magento Imagine](https://www.adobe.com/summit.html)"
   status: online-only
-
+  
+- name: "[Adobe ColdFusion Summit East 2020](https://carahevents.carahsoft.com/CFSummit2020/)"
+  status: cancelled
+  
 - name: "[American Quarter Horse Association Convention 2020](https://www.aqha.com/-/2020-aqha-convention?redirect=/)"
   status: cancelled
 


### PR DESCRIPTION
Adds or updates the following events or companies:

 - Added Adobe ColdFusion Summit East 2020  https://carahevents.carahsoft.com/CFSummit2020/
 - 

### Checklist

### Company updates
 - [ ] I have put the most recent relevant date in the "Last Update" column
 - [ ] I have linked to the article about the change, not the company's website (Please put N/A if there is no public post)

### Event updates
 - [ x] I have linked to the article about the change, not the event's website