### PR TITLE
Add Pleo to the list of companies

### DIFF
--- a/_data/companies.yml
+++ b/_data/companies.yml
@@ -1131,6 +1131,13 @@
   visitors: Restricted
   events: Partially Restricted
   last_update: 2020-03-08
+  
+- name: Pleo
+  wfh: Required
+  travel: Restricted
+  visitors: Restricted
+  events: Restricted
+  last_update: 2020-03-12
 
 - name: Polidea
   wfh: Encouraged


### PR DESCRIPTION
Pleo is now requiring all employees to work from home.

Adds or updates the following companies:
 - Pleo

### Checklist

### Company updates
 - [x] I have put the most recent relevant date in the "Last Update" column
 - [N/A] I have linked to the article about the change, not the company's website (Please put N/A if there is no public post)

Source: I'm a director of engineering at Pleo.