### PR TITLE
Added WC Europe 2020

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -420,3 +420,6 @@
 
 - name: "[WordCamp Jacksonville 2020](https://2020.jacksonville.wordcamp.org/)"
   status: cancelled
+
+- name: "[WordCamp Europe 2020](https://2020.europe.wordcamp.org/2020/03/12/important-notice-wordcamp-europe-postponed/)"
+  status: postponed to 2021


### PR DESCRIPTION
Adds or updates the following events or companies:
 - WordCamp Europe 2020 in Porto


### Checklist

### Company updates
 - [ ] I have put the most recent relevant date in the "Last Update" column
 - [ ] I have linked to the article about the change, not the company's website (Please put N/A if there is no public post)

### Event updates
 - [x] I have linked to the article about the change, not the event's website