### PR TITLE
Patch 4 - Add Pipedrive to the list of companies with reference 

### DIFF
--- a/_data/companies.yml
+++ b/_data/companies.yml
@@ -1202,7 +1202,7 @@
   events: Restricted
   last_update: 2020-03-12
 
-- name: Pipedrive
+- name: Pipedrive[[1]](https://twitter.com/pipedrive/status/1238152383475179520)
   wfh: Required
   travel: Restricted
   visitors: Restricted

--- a/_data/companies.yml
+++ b/_data/companies.yml
@@ -271,13 +271,6 @@
   events: Restricted
   last_update: 2020-03-12
 
-- name: ChargedUp
-  wfh: Encouraged
-  travel: Restricted
-  visitors: Restricted
-  events: Restricted
-  last_update: 2020-03-12
-
 - name: "charity: water"
   wfh: Required
   travel: Restricted
@@ -1209,6 +1202,13 @@
   events: Restricted
   last_update: 2020-03-12
 
+- name: Pipedrive
+  wfh: Required
+  travel: Restricted
+  visitors: Restricted
+  events: Restricted
+  last_update: 2020-03-12
+
 - name: PipelineDeals
   wfh: Required
   travel: Restricted
@@ -1432,13 +1432,6 @@
   visitors: "?"
   events: Restricted
   last_update: 2020-03-06
-
-- name: Spreedly
-  wfh: Required
-  travel: Restricted
-  visitors: Restricted
-  events: Restricted
-  last_update: 2020-03-12
 
 - name: Springboard (aka SlideRule Labs Inc.)
   wfh: Encouraged, Recommended for Bangalore


### PR DESCRIPTION
Adds or updates the following events or companies:
 - Company: Pipedrive

### Checklist

### Company updates
 - [x] I have put the most recent relevant date in the "Last Update" column
 - [x] I have linked to the article about the change, not the company's website (Please put N/A if there is no public post)
