### PR TITLE
Update Spotify WFH to 'Required'

### DIFF
--- a/_data/companies.yml
+++ b/_data/companies.yml
@@ -1448,7 +1448,7 @@
   last_update: 2020-03-09
 
 - name: Spotify[[1]](https://twitter.com/eldsjal/status/1237487784996343813)
-  wfh: Encouraged
+  wfh: Required
   travel: Restricted
   visitors: Restricted
   events: Restricted


### PR DESCRIPTION
I'm an employee of Spotify in Sweden. No one is actually allowed to work from office, even though the wording in the original tweet makes a bit of a softer statement.