### PR TITLE
Add Lead Dev NY to events

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -220,6 +220,9 @@
 - name: "[Kentico Partner Summit Q2 2020](https://www.eventbrite.com/e/q2-2020-kentico-partner-summit-tickets-91103997509)"
   status: postponed until later this year
 
+- name: "[Lead Dev New York 2020](https://newyork2020.theleaddeveloper.com/covid-19-update)"
+  status: postponed until August 11 & 12, 2020
+
 - name: "[Lesbians Who Tech](https://twitter.com/ArlanWasHere/status/1234622619867066368?s=20)"
   status: postponed until August 6-8, 2020 pending developments
 


### PR DESCRIPTION
Adds or updates the following events or companies:
 - Lead Dev NY

### Checklist

### Company updates
 - [ ] I have put the most recent relevant date in the "Last Update" column
 - [ ] I have linked to the article about the change, not the company's website (Please put N/A if there is no public post)

### Event updates
 - [x] I have linked to the article about the change, not the event's website