### PR TITLE
Added Nike LA 13.1 Half Marathon to events

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -265,6 +265,9 @@
 - name: "[NG-CONF](https://www.ng-conf.org/)"
   status: changed to a virtual event
 
+- name: "[Nike LA 13.1 Half Marathon](https://www.nike.com/us/en_us/e/cities/losangeles/la-131)"
+  status: cancelled
+
 - name: "[Nvidia GPU Technology Conference (GTC) 2020](https://www.theverge.com/2020/3/2/21161635/nvidias-gpu-technology-conference-gtc-online-only-coronavirus)"
   status: online-only
 


### PR DESCRIPTION
Adds or updates the following events or companies:
 - Nike LA 13.1 Half Marathon (event)

### Checklist

### Company updates
 - [ ] I have put the most recent relevant date in the "Last Update" column
 - [ ] I have linked to the article about the change, not the company's website (Please put N/A if there is no public post)

### Event updates
 - [x] I have linked to the article about the change, not the event's website (N/A -- site has been updated but no direct article)