### PR TITLE
Add sofatutor to the companies list

### DIFF
--- a/_data/companies.yml
+++ b/_data/companies.yml
@@ -1419,6 +1419,13 @@
   events: "?"
   last_update: 2020-03-11
 
+- name: sofatutor
+  wfh: Required
+  travel: "?"
+  visitors: "?"
+  events: Restricted
+  last_update: 2020-03-12
+
 - name: SoftServe
   wfh: Encouraged
   travel: Restricted


### PR DESCRIPTION
Adds or updates the following events or companies:
 - sofatutor

### Checklist

### Company updates
 - [x] I have put the most recent relevant date in the "Last Update" column
 - [x] I have linked to the article about the change, not the company's website (Please put N/A if there is no public post) – There's no public post.

### Event updates
 - [ ] I have linked to the article about the change, not the event's website