### PR TITLE
Add Redbubble.

### DIFF
--- a/_data/companies.yml
+++ b/_data/companies.yml
@@ -1419,6 +1419,13 @@
   events: Restricted
   last_update: 2020-03-12
 
+- name: Redbubble
+  wfh: Strongly Encouraged
+  travel: Restricted
+  visitors: Restricted
+  events: Restricted
+  last_update: 2020-03-12
+
 - name: Redfin[[1]](https://www.seattletimes.com/business/some-seattle-tech-companies-tell-employees-to-work-from-home-to-slow-spread-of-coronavirus/)
   wfh: Encouraged
   travel: "?"


### PR DESCRIPTION
Redid the change, because of horrible merge conflicts.  Supersedes #376. 

Adds or updates the following events or companies:
 - Redbubble

### Company updates
- [n/a] I have updated the event or company counts
- [yes] I have put the most recent relevant date in the "Last Update" column
- [n/a] I have linked to the article about the change, not the company's website

Co-authored-by: Daniel Vydra <daniel.vydra@redbubble.com>