### PR TITLE
Updated Gem's status

### DIFF
--- a/_data/companies.yml
+++ b/_data/companies.yml
@@ -755,11 +755,11 @@
   last_update: 2020-03-12
 
 - name: Gem
-  wfh: Optional
+  wfh: Strongly Recommended
   travel: Restricted
   visitors: Restricted
   events: Restricted
-  last_update: 2020-03-11
+  last_update: 2020-03-12
 
 - name: General Dynamics
   wfh: Optional


### PR DESCRIPTION
Adds or updates the following events or companies:
 - Updates Gem's WFH status from optional to strongly encouraged
 - 

### Checklist

### Company updates
 - [x] I have put the most recent relevant date in the "Last Update" column
 - [n/a ] I have linked to the article about the change, not the company's website (Please put N/A if there is no public post)

### Event updates
 - [ ] I have linked to the article about the change, not the event's website