### PR TITLE
Update companies.yml for OfferUp

### DIFF
--- a/_data/companies.yml
+++ b/_data/companies.yml
@@ -1294,11 +1294,11 @@
   last_update: 2020-03-12
 
 - name: OfferUp
-  wfh: Encouraged
+  wfh: Required
   travel: Restricted
   visitors: Restricted
   events: Restricted
-  last_update: 2020-03-06
+  last_update: 2020-03-12
 
 - name: Okta
   wfh: Required


### PR DESCRIPTION
OfferUp moves to 100% mandatory WFH

Adds or updates the following events or companies:
 - OfferUp (N/A public post)