### PR TITLE
Add Cruisin' for a Bluesin'

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -85,6 +85,9 @@
 - name: "[Collision](https://collisionconf.com/)"
   status: moving to virtual event
 
+- name: "[Cruisin' for a Bluesin'](https://mailchi.mp/04231504de9e/important-pls-read-c4ab20-cancellation-details)"
+  status: cancelled
+
 - name: "[Deconstruct](https://www.deconstructconf.com/)"
   status: cancelled
 


### PR DESCRIPTION
Adds or updates the following events or companies:
 - Event: Cruisin' for a Bluesin'
 - 

### Checklist

### Company updates
 - [ ] I have put the most recent relevant date in the "Last Update" column
 - [ ] I have linked to the article about the change, not the company's website (Please put N/A if there is no public post)

### Event updates
 - [x] I have linked to the article about the change, not the event's website