### PR TITLE
feat: add housinganywhere.com

### DIFF
--- a/_data/companies.yml
+++ b/_data/companies.yml
@@ -908,6 +908,13 @@
   events: Restricted
   last_update: 2020-03-12
 
+- name: HousingAnywhere.com
+  wfh: Required
+  travel: Restricted
+  visitors: Restricted
+  events: Restricted
+  last_update: 2020-03-13
+
 - name: Houzz
   wfh: Optional
   travel: Restricted


### PR DESCRIPTION
Adds or updates the following events or companies:
 - HousingAnywhere.com
 - No public post about it so far

### Checklist

### Company updates
 - [x] I have put the most recent relevant date in the "Last Update" column
 - [ ] I have linked to the article about the change, not the company's website (Please put N/A if there is no public post)

### Event updates
 - [ ] I have linked to the article about the change, not the event's website