### PR TITLE
Add in McGraw-Hill

### DIFF
--- a/_data/companies.yml
+++ b/_data/companies.yml
@@ -1110,6 +1110,13 @@
   visitors: N/A
   events: Restricted
   last_update: 2020-03-09
+  
+- name: McGraw-Hill
+  wfh: Encouraged
+  travel: Restricted
+  visitors: Restricted
+  events: Restricted
+  last_update: 2020-03-13
 
 - name: Medaptive Health
   wfh: Required

--- a/_data/companies.yml
+++ b/_data/companies.yml
@@ -1110,7 +1110,7 @@
   visitors: N/A
   events: Restricted
   last_update: 2020-03-09
-  
+
 - name: McGraw-Hill
   wfh: Encouraged
   travel: Restricted


### PR DESCRIPTION
I work here and received an email today fully encouraging company wide wfh and restrictions.

Adds or updates the following events or companies:
 - McGraw-Hill (Formally named: McGraw-Hill Education)

### Checklist

### Company updates
 - [X] I have put the most recent relevant date in the "Last Update" column
 - [N/A] I have linked to the article about the change, not the company's website (Please put N/A if there is no public post)

### Event updates
 - [N/A] I have linked to the article about the change, not the event's website