### PR TITLE
Add Drupal Dev Days to events list

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -124,6 +124,9 @@
 - name: "[Dreamforce World Tour (Sydney)](https://www.arnnet.com.au/article/671175/salesforce-world-tour-sydney-goes-digital-amid-coronavirus-fears/)"
   status: cancelled
 
+- name: "[Drupal Dev Days 2020](https://drupalcamp.be/en/drupal-dev-days-2020/coronavirus)"
+  status: postponed, no date given
+
 - name: "[E3 2020](https://arstechnica.com/gaming/2020/03/e3-2020-has-been-canceled/)"
   status: canceled
 


### PR DESCRIPTION
Adds or updates the following events or companies:
 - [Drupal Dev Days 2020](https://drupalcamp.be/en/drupal-dev-days-2020)

### Event updates
 - [x] I have linked to the article about the change, not the event's website