### PR TITLE
add company move:elevator

### DIFF
--- a/_data/companies.yml
+++ b/_data/companies.yml
@@ -1369,6 +1369,13 @@
   visitors: Discouraged
   events: Required
   last_update: 2020-03-12
+  
+- name: move elevator GmbH
+  wfh: Encouraged
+  travel: Restricted
+  visitors: Discouraged
+  events: Restricted
+  last_update: 2020-03-13
 
 - name: Moz[[1]](https://www.geekwire.com/2020/coronavirus-live-updates-seattle-tech-community-grappling-covid-19/2/)
   wfh: Required
@@ -2678,10 +2685,3 @@
   visitors: Restricted
   events: Restricted
   last_update: 2020-03-12
-
-- name: Stack Overflow [[1]](https://stackoverflow.blog/2020/03/09/a-message-to-our-employees-community-and-customers-on-covid-19/)
-  wfh: Required
-  travel: Restricted
-  visitors: Restricted
-  events: Restricted
-  last_update: 2020-03-13


### PR DESCRIPTION
Adds or updates the following companies, events, or universities:
 - move elevator GmbH -> Statement on Homepage: https://www.move-elevator.de/

### Checklist

#### Company updates
 - [x] I have put the most recent relevant date in the "Last Update" column
 - [x] I have linked to the article about the change, not the company's homepage (Please put N/A if there is no public post)
