### PR TITLE
Add Southern Data Science Conference

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -376,6 +376,9 @@
 - name: "[SNUG Silicon Valley](https://www.synopsys.com/community/snug/snug-silicon-valley.html)"
   status: cancelled
 
+- name: "[Southern Data Science Conference](https://www.southerndatascience.com/covid19)"
+  status: Postponed until August 12-14  
+
 - name: "[SQLBits](https://sqlbits.com/)"
   status: Postponed until September
 


### PR DESCRIPTION
Adds or updates the following companies, events, or universities:
 - Southern Data Science Conference

### Checklist

#### Company updates
 - [ ] I have put the most recent relevant date in the "Last Update" column
 - [ ] I have linked to the article about the change, not the company's homepage (Please put N/A if there is no public post)

#### Event updates
 - [x] I have linked to the article about the change, not the event's homepage

#### University updates
 - [ ] I have linked to the article about the change, not the university's homepage
