### PR TITLE
AWS San Francisco 2020 has been canceled

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -40,6 +40,9 @@
 - name: "[AWS Summit Paris](https://aws.amazon.com/fr/events/summits/paris/)"
   status: cancelled
 
+- name: "[AWS Summit San Francisco 2020](https://aws.amazon.com/events/summits/san-francisco/2020/)"
+  status: cancelled
+
 - name: "[AWS Summit Sydney](https://aws.amazon.com/events/summits/sydney/)"
   status: cancelled
 


### PR DESCRIPTION
Adds or updates the following companies, events, or universities:
 - AWS San Francisco 2020

### Checklist

#### Event updates
 - [X] I have linked to the article about the change, not the event's homepage
