### PR TITLE
Added Microsoft Build

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -40,9 +40,6 @@
 - name: "[AWS Summit Paris](https://aws.amazon.com/fr/events/summits/paris/)"
   status: cancelled
 
-- name: "[AWS Summit San Francisco 2020](https://aws.amazon.com/events/summits/san-francisco/2020/)"
-  status: cancelled
-
 - name: "[AWS Summit Sydney](https://aws.amazon.com/events/summits/sydney/)"
   status: cancelled
 
@@ -259,6 +256,9 @@
 - name: "[Micro Focus Universe The Hague](https://universe.microfocus.com/)"
   status: moving to virtual event Micro Focus Virtual Universe 2020
 
+- name: "[Microsoft Build](https://twitter.com/shanselman/status/1238286913636716547)"
+  status: changed to a virtual event
+  
 - name: "[Microsoft Ignite the Tour Amsterdam](https://www.microsoft.com/nl-nl/ignite-the-tour/amsterdam)"
   status: cancellation announced March 2, 2020
 


### PR DESCRIPTION
Added information on Microsoft Build 2020 changing to virtual event.
No blog post or event page update yet, so linking to Scott Hanselman's tweet.

Adds the following event:
 - Microsoft Build

### Checklist

#### Event updates
 - [x] I have linked to the article about the change, not the event's homepage
No article available, so linked to Scott Hanselman's tweet.
