### PR TITLE
Add Crestron Masters 2020

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -94,6 +94,9 @@
 - name: "[Collision](https://collisionconf.com/)"
   status: moving to virtual event
 
+- name: "[Crestron Masters 2020](https://www.crestron.com/Training-Events/Masters-2020)"
+  status: postponed
+
 - name: "[Cruisin' for a Bluesin'](https://mailchi.mp/04231504de9e/important-pls-read-c4ab20-cancellation-details)"
   status: cancelled
 


### PR DESCRIPTION
Adds or updates the following companies, events, or universities:
 - Crestron Masters 2020
 - 

### Checklist

#### Company updates
 - [ ] I have put the most recent relevant date in the "Last Update" column
 - [ ] I have linked to the article about the change, not the company's homepage (Please put N/A if there is no public post)

#### Event updates
 - [x] I have linked to the article about the change, not the event's homepage

#### University updates
 - [ ] I have linked to the article about the change, not the university's homepage
