### PR TITLE
Add Diffbot to company list

### DIFF
--- a/_data/companies.yml
+++ b/_data/companies.yml
@@ -649,6 +649,13 @@
   events: Restricted
   last_update: 2020-03-12
 
+- name: Diffbot
+  wfh: Encouraged
+  travel: Restricted
+  visitors: Restricted
+  events: Restricted
+  last_update: 2020-03-13
+  
 - name: DNAnexus
   wfh: Required
   travel: Restricted


### PR DESCRIPTION
Adds or updates the following companies, events, or universities:
 - Diffbot company based on Menlo Park, CA
 - 

### Checklist

#### Company updates
 - [x] I have put the most recent relevant date in the "Last Update" column
 - [N/A] I have linked to the article about the change, not the company's homepage (Please put N/A if there is no public post)

#### Event updates
 - [ ] I have linked to the article about the change, not the event's homepage

#### University updates
 - [ ] I have linked to the article about the change, not the university's homepage
