### PR TITLE
Adds Catawiki

### DIFF
--- a/_data/companies.yml
+++ b/_data/companies.yml
@@ -452,6 +452,13 @@
   visitors: Restricted
   events: Restricted
   last_update: 2020-03-12
+  
+- name: Catawiki
+  wfh: Required
+  travel: Restricted
+  visitors: Restricted
+  events: Restricted
+  last_update: 2020-03-12
 
 - name: CB Insights
   wfh: Required


### PR DESCRIPTION
Adds or updates the following companies, events, or universities:
Catawiki B.V.

#### Company updates
 - [X] I have put the most recent relevant date in the "Last Update" column
 - [X] No public post