### PR TITLE
Update based on last internal comms at @Intercom

### DIFF
--- a/_data/companies.yml
+++ b/_data/companies.yml
@@ -1407,11 +1407,11 @@
   last_update: 2020-03-09
 
 - name: Intercom [[1]](https://twitter.com/fergal_reid/status/1237878256054886411)
-  wfh: Recommended
-  travel: "?"
-  visitors: "?"
-  events: "?"
-  last_update: 2020-03-04
+  wfh: Encouraged
+  travel: Restricted
+  visitors: Restricted
+  events: Restricted
+  last_update: 2020-03-05
 
 - name: Internet Archive [[1]](https://twitter.com/brewster_kahle/status/1237194160949489670)
   wfh: Required


### PR DESCRIPTION
Re-submitting this since https://github.com/phildini/stayinghomeclub/pull/838 went wrong somehow.

From most recent internal communication (5th March, 2020): 

> Out of an abundance of caution and care, we have made the following decisions, which will go into immediate effect and will stay in effect until further notice:
> - We are encouraging all employees to work from home. 
> - We are suspending all business travel and asking international travellers to stay at home for a period.
> - We are not allowing any external visitors to our offices.

*(Source: I’m a current employee)*

Updates the following companies:
 - Intercom (@intercom)