### PR TITLE
Fix bad Red Hat link

### DIFF
--- a/_data/companies.yml
+++ b/_data/companies.yml
@@ -2163,7 +2163,7 @@
   events: "?"
   last_update: 2020-03-04
   
-- name: Red Hat [1]](https://www.redhat.com/en/blog/what-red-hat-doing-address-coronavirus-covid-19?sc_cid=701f2000000tyBjAAI)
+- name: Red Hat [[1]](https://www.redhat.com/en/blog/what-red-hat-doing-address-coronavirus-covid-19?sc_cid=701f2000000tyBjAAI)
   wfh: Required
   travel: Restricted
   visitors: "?"


### PR DESCRIPTION
Adds or updates the following companies, events, or universities:
 - N/A, syntax fix

### Checklist

#### Company updates
 - [ ] I have put the most recent relevant date in the "Last Update" column
 - [ ] I have linked to the article about the change, not the company's homepage (Please put N/A if there is no public post)

#### Event updates
 - [ ] I have linked to the article about the change, not the event's homepage

#### University updates
 - [ ] I have linked to the article about the change, not the university's homepage
