### PR TITLE
Cornell and Harvard Universities

### DIFF
--- a/_data/universities/edu.cornell.yml
+++ b/_data/universities/edu.cornell.yml
@@ -1,0 +1,7 @@
+name: "[Cornell University](https://www.cornell.edu/coronavirus/)"
+status: Effective at 5:00 p.m. today (Friday, March 13), we are suspending all classes on the Ithaca campus for three weeks. Virtual instruction will begin on Monday, April 6.
+last_update: 2020-03-14
+start: 2020-03-13
+expected_end:
+wfh: The university remains open, but units across the university are in the process of finalizing their remote work plans. Those plans must be implemented no later than Friday, March 20.
+last_update: 2020-03-13

--- a/_data/universities/edu.cornell.yml
+++ b/_data/universities/edu.cornell.yml
@@ -3,4 +3,3 @@ status: "Effective at 5:00 p.m. today (Friday, March 13), we are suspending all 
 last_update: 2020-03-14
 start: 2020-03-13
 expected_end:
-wfh: "The university remains open, but units across the university are in the process of finalizing their remote work plans. Those plans must be implemented no later than Friday, March 20."

--- a/_data/universities/edu.cornell.yml
+++ b/_data/universities/edu.cornell.yml
@@ -1,6 +1,6 @@
 name: "[Cornell University](https://www.cornell.edu/coronavirus/)"
-status: Effective at 5:00 p.m. today (Friday, March 13), we are suspending all classes on the Ithaca campus for three weeks. Virtual instruction will begin on Monday, April 6.
+status: "Effective at 5:00 p.m. today (Friday, March 13), we are suspending all classes on the Ithaca campus for three weeks. Virtual instruction will begin on Monday, April 6."
 last_update: 2020-03-14
 start: 2020-03-13
 expected_end:
-wfh: The university remains open, but units across the university are in the process of finalizing their remote work plans. Those plans must be implemented no later than Friday, March 20.
+wfh: "The university remains open, but units across the university are in the process of finalizing their remote work plans. Those plans must be implemented no later than Friday, March 20."

--- a/_data/universities/edu.cornell.yml
+++ b/_data/universities/edu.cornell.yml
@@ -4,4 +4,3 @@ last_update: 2020-03-14
 start: 2020-03-13
 expected_end:
 wfh: The university remains open, but units across the university are in the process of finalizing their remote work plans. Those plans must be implemented no later than Friday, March 20.
-last_update: 2020-03-13

--- a/_data/universities/edu.harvard.yml
+++ b/_data/universities/edu.harvard.yml
@@ -1,5 +1,5 @@
 name: "[Harvard University](https://www.harvard.edu/coronavirus)"
 status: "Effective March 10 and until further notice. We will begin transitioning to online instruction for all graduate and undergraduate classes. The goal is to complete this transition by March 23."
 last_update: 2020-03-14
-start: 2020-03-13
+start: 2020-03-23
 expected_end:

--- a/_data/universities/edu.harvard.yml
+++ b/_data/universities/edu.harvard.yml
@@ -1,0 +1,5 @@
+name: "[Harvard University](https://www.harvard.edu/coronavirus)"
+status: Effective March 10 and until further notice: We will begin transitioning to online instruction for all graduate and undergraduate classes. The goal is to complete this transition by March 23
+last_update: 2020-03-14
+start: 2020-03-13
+expected_end:

--- a/_data/universities/edu.harvard.yml
+++ b/_data/universities/edu.harvard.yml
@@ -1,5 +1,5 @@
 name: "[Harvard University](https://www.harvard.edu/coronavirus)"
-status: Effective March 10 and until further notice: We will begin transitioning to online instruction for all graduate and undergraduate classes. The goal is to complete this transition by March 23
+status: "Effective March 10 and until further notice. We will begin transitioning to online instruction for all graduate and undergraduate classes. The goal is to complete this transition by March 23."
 last_update: 2020-03-14
 start: 2020-03-13
 expected_end:


### PR DESCRIPTION
Adds or updates the following companies, events, or universities:
 - Cornell University
 - Harvard University

### Checklist

#### University updates
 - [x] I have linked to the article about the change, not the university's homepage
