### PR TITLE
Add source for NASA Marshall closure, update date to match

### DIFF
--- a/_data/companies/nasa-marshall.yml
+++ b/_data/companies/nasa-marshall.yml
@@ -1,7 +1,7 @@
 ---
-name: NASA Marshall
-wfh: Required through 2020-03-27 
+name: "NASA Marshall [[1]](https://www.nasa.gov/centers/marshall/news/releases/2020/20-006.html)"
+wfh: Required for everyone except "mission-essential personnel" 
 travel: "?"
 visitors: "?"
 events: "?"
-last_update: 2020-03-14
+last_update: 2020-03-13


### PR DESCRIPTION
Adds or updates the following companies, events, or universities:
 - NASA Marshall (adds link)

### Checklist

#### Company updates
 - [x] I have put the most recent relevant date in the "Last Update" column
 - [x] I have linked to the article about the change, not the company's homepage (Please put N/A if there is no public post)
