### PR TITLE
Update Intuit wfh to "Strongly Encouraged"

### DIFF
--- a/_data/companies/intuit.yml
+++ b/_data/companies/intuit.yml
@@ -1,7 +1,7 @@
 ---
 name: Intuit
-wfh: Encouraged
+wfh: Strongly Encouraged
 travel: Restricted
 visitors: Restricted
 events: Restricted
-last_update: 2020-03-06
+last_update: 2020-03-12


### PR DESCRIPTION
Adds or updates the following companies:
 - Intuit

### Checklist

#### Company updates
 - [x] I have put the most recent relevant date in the "Last Update" column
 - [N/A] I have linked to the article about the change, not the company's homepage (Please put N/A if there is no public post)

No public post, but Company offices are essentially empty.