### PR TITLE
Add Australian Grand Prix

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -205,6 +205,12 @@
 - name: "[Formula 1 Vietnam Grand Prix](https://www.formula1.com/en/latest/article.f1-and-coronavirus-what-do-we-know-so-far.5hlhF1oeT6rJbfbUpPMrqI.html)"
   status: postponed
 
+- name: "[Formula 1 Chinese Grand Prix](https://www.formula1.com/en/latest/article.chinese-grand-prix-postponed-due-to-coronavirus-outbreak.3g2y5Ngyrk1MbNxQB9hj4s.html)"
+  status: postponed
+  
+- name: "[Formula 1 Joburg Festival, South Africa](https://www.formula1.com/en/latest/article.f1-joburg-festival-postponed-as-covid-19-precaution.wzjqLLeKvjgDSZMOr4thK.html)"
+  status: postponed
+
 - name: "[Game Developers Conference (GDC)](https://www.gdconf.com/news/important-gdc-2020-update)"
   status: postponed
 

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -196,7 +196,7 @@
 - name: "[Flink Forward (Apache Flink)](https://www.flink-forward.org/sf-2020)"
   status: cancelled, considering moving to virtual
 
-- name: "[Formula1 Australian Grand Prix](https://grandprix.com.au/fan-zone/news/statement-regarding-formula-1-australian-grand-prix)"
+- name: "[Formula 1 Australian Grand Prix](https://grandprix.com.au/fan-zone/news/statement-regarding-formula-1-australian-grand-prix)"
   status: cancelled
 
 - name: "[Game Developers Conference (GDC)](https://www.gdconf.com/news/important-gdc-2020-update)"

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -196,6 +196,9 @@
 - name: "[Flink Forward (Apache Flink)](https://www.flink-forward.org/sf-2020)"
   status: cancelled, considering moving to virtual
 
+- name: "[Formula1 Australian Grand Prix](https://grandprix.com.au)"
+  status: cancelled
+
 - name: "[Game Developers Conference (GDC)](https://www.gdconf.com/news/important-gdc-2020-update)"
   status: postponed
 

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -199,6 +199,12 @@
 - name: "[Formula 1 Australian Grand Prix](https://grandprix.com.au/fan-zone/news/statement-regarding-formula-1-australian-grand-prix)"
   status: cancelled
 
+- name: "[Formula 1 Bahrain Grand Prix](https://www.formula1.com/en/latest/article.f1-and-coronavirus-what-do-we-know-so-far.5hlhF1oeT6rJbfbUpPMrqI.html)"
+  status: postponed
+  
+- name: "[Formula 1 Vietnam Grand Prix](https://www.formula1.com/en/latest/article.f1-and-coronavirus-what-do-we-know-so-far.5hlhF1oeT6rJbfbUpPMrqI.html)"
+  status: postponed
+
 - name: "[Game Developers Conference (GDC)](https://www.gdconf.com/news/important-gdc-2020-update)"
   status: postponed
 

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -196,7 +196,7 @@
 - name: "[Flink Forward (Apache Flink)](https://www.flink-forward.org/sf-2020)"
   status: cancelled, considering moving to virtual
 
-- name: "[Formula1 Australian Grand Prix](https://grandprix.com.au)"
+- name: "[Formula1 Australian Grand Prix](https://grandprix.com.au/fan-zone/news/statement-regarding-formula-1-australian-grand-prix)"
   status: cancelled
 
 - name: "[Game Developers Conference (GDC)](https://www.gdconf.com/news/important-gdc-2020-update)"


### PR DESCRIPTION
Adds or updates the following companies, events, or universities:
 - Australian Formula 1 Grand Prix

### Checklist

#### Event updates
 - [X] I have linked to the article about the change, not the event's homepage
