### PR TITLE
Add Revision Demoparty 2020

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -391,7 +391,7 @@
 - name: "[Red Team Summit](https://www.zdnet.com/article/a-list-of-security-conferences-canceled-or-postponed-due-to-coronavirus-concerns/)"
   status: postponed until June 11-12
 
-- name: "[Revison Demoparty 2020](https://2020.revision-party.net/cancellation)"
+- name: "[Revision Demoparty 2020](https://2020.revision-party.net/cancellation)"
   status: moving to virtual event
 
 - name: "[Rocket League World Championship](https://www.rocketleague.com/news/important-rocket-league-esports-update/)"

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -391,6 +391,9 @@
 - name: "[Red Team Summit](https://www.zdnet.com/article/a-list-of-security-conferences-canceled-or-postponed-due-to-coronavirus-concerns/)"
   status: postponed until June 11-12
 
+- name: "[Revison Demoparty 2020](https://2020.revision-party.net/cancellation)"
+  status: moving to virtual event
+
 - name: "[Rocket League World Championship](https://www.rocketleague.com/news/important-rocket-league-esports-update/)"
   status: cancelled
 


### PR DESCRIPTION
Adds or updates the following companies, events, or universities:
 - Revision Demoparty 2020

### Checklist
#### Event Updates
 - [x] I have linked to the article about the change, not the event's homepage
