### PR TITLE
Add Surfline Wavetrak

### DIFF
--- a/_data/companies/surfline-wavetrak.yml
+++ b/_data/companies/surfline-wavetrak.yml
@@ -1,0 +1,7 @@
+---
+name: Surfline Wavetrak
+wfh: Required
+travel: Restricted
+visitors: Restricted
+events: Restricted
+last_update: 2020-03-16


### PR DESCRIPTION
Adds or updates the following companies, events, or universities:
 - Surfline Wavetrak

### Checklist

#### Company updates
 - [x] I have put the most recent relevant date in the "Last Update" column
 - [x] (N/A) I have linked to the article about the change, not the company's homepage (Please put N/A if there is no public post)

#### Event updates
 - [ ] I have linked to the article about the change, not the event's homepage

#### University updates
 - [ ] I have linked to the article about the change, not the university's homepage
