### PR TITLE
Add EuroPython

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -157,6 +157,9 @@
 - name: "[Emerald City Comic Con (ECCC)](https://www.emeraldcitycomiccon.com/About/A-Statement-From-Reedpop/)"
   status: Rescheduled for August 21st-23rd
 
+- name: "[EuroPython 2020](http://blog.europython.eu/post/612826526375919616/europython-2020-going-virtual-europython-2021)"
+  status: moving to virtual event
+
 - name: "[EVE Online Fanfest](https://www.eveonline.com/article/q6f8js/eve-fanfest-2020-canceled)"
   status: canceled
 


### PR DESCRIPTION
Adds or updates the following companies, events, or universities:
 - EuroPython 2020 event: going virtual. In-person meeting in Dublin, Ireland will happen next year

### Checklist

#### Company updates
 - ~~I have put the most recent relevant date in the "Last Update" column~~
 - ~~I have linked to the article about the change, not the company's homepage (Please put N/A if there is no public post)~~

#### Event updates
 - [x] I have linked to the article about the change, not the event's homepage

#### University updates
 - ~~I have linked to the article about the change, not the university's homepage~~
