### PR TITLE
NYU closing student residence

### DIFF
--- a/_data/universities/edu.nyu.yml
+++ b/_data/universities/edu.nyu.yml
@@ -1,5 +1,5 @@
 name: "[New York University](https://www.nyu.edu/life/safety-health-wellness/coronavirus-information/our-global-communities.html#nyc)"
-status: From Wednesday, March 11 until at least April 19, NYU’s classes will be conducted remotely in New York and Brooklyn.
-last_update: 2020-03-12
+status: From Wednesday, March 11 until at least April 19, NYU’s classes will be conducted remotely in New York and Brooklyn. New York student residence to be closed as of March 22.
+last_update: 2020-03-16
 start: 2020-03-11
 expected_end: 2020-04-19


### PR DESCRIPTION
Adds or updates the following companies, events, or universities:
 - New York University: student residence to close. Students to return home by March 22

### Checklist

#### Company updates
 - [ ] ~~I have put the most recent relevant date in the "Last Update" column~~
 - [ ] ~~I have linked to the article about the change, not the company's homepage (Please put N/A if there is no public post)~~

#### Event updates
 - [ ] ~~I have linked to the article about the change, not the event's homepage~~

#### University updates
 - [x] I have linked to the article about the change, not the university's homepage
