### PR TITLE
Add React Sydney Event: Postponed

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -403,6 +403,9 @@
 - name: "[RailsConf2020](https://railsconf.com/)"
   status: cancelled
 
+- name: "[React Sydney meetup](https://twitter.com/reactsydney/status/1238009146621833216)"
+  status: postponed
+
 - name: "[Red Hat Summit](https://www.redhat.com/en/summit)"
   status: moving to virtual event
 


### PR DESCRIPTION
Adds or updates the following companies, events, or universities:
 - React Sydney: https://twitter.com/reactsydney/status/1238009146621833216


### Checklist

#### Event updates
 - [x] I have linked to the article about the change, not the event's homepage
