### PR TITLE
added foodly gmbh – 10625 berlin

### DIFF
--- a/_data/companies/foodly.yml
+++ b/_data/companies/foodly.yml
@@ -1,0 +1,6 @@
+name: Foodly
+wfh: Required
+travel: Restricted
+visitors: Restricted
+events: Restricted
+last_update: 2020-03-18


### PR DESCRIPTION
Adds or updates the following companies, events, or universities:
 - Foodly GmbH - 10625 Berlin

### Checklist

#### Company updates
 - [x ] I have put the most recent relevant date in the "Last Update" column
 - [ x] I have linked to the article about the change, not the company's homepage (Please put N/A if there is no public post)

#### Event updates
 - [ ] I have linked to the article about the change, not the event's homepage

#### University updates
 - [ ] I have linked to the article about the change, not the university's homepage
