### PR TITLE
All GitHub offices are now closed 📪

### DIFF
--- a/_data/companies/github--1---https---github-blog-2020-03-03-covi....yml
+++ b/_data/companies/github--1---https---github-blog-2020-03-03-covi....yml
@@ -4,4 +4,4 @@ wfh: Required
 travel: Restricted
 visitors: Restricted
 events: Restricted
-last_update: 2020-03-13
+last_update: 2020-03-18

--- a/_data/companies/github--1---https---github-blog-2020-03-03-covi....yml
+++ b/_data/companies/github--1---https---github-blog-2020-03-03-covi....yml
@@ -1,6 +1,6 @@
 ---
 name: GitHub[[1]](https://github.blog/2020-03-03-covid-19-update-supporting-our-employees-and-community/)
-wfh: Encouraged
+wfh: Required
 travel: Restricted
 visitors: Restricted
 events: Restricted


### PR DESCRIPTION
Adds or updates the following companies, events, or universities:
 - GitHub

### Checklist

#### Company updates
 - [x] I have put the most recent relevant date in the "Last Update" column
 - [x] ~~I have linked to the article about the change, not the company's homepage~~ Latest post is https://github.blog/2020-03-16-enhancing-our-covid-19-response-to-care-for-our-community-and-team/, but we closed SF yesterday (as per shelter in place) and all offices today via internal post.