### PR TITLE
Condense F1 races into one line

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -202,17 +202,8 @@
 - name: "[Flink Forward (Apache Flink)](https://www.flink-forward.org/sf-2020)"
   status: cancelled, considering moving to virtual
 
-- name: "[Formula 1 Australian Grand Prix](https://grandprix.com.au/fan-zone/news/statement-regarding-formula-1-australian-grand-prix)"
-  status: cancelled
-
-- name: "[Formula 1 Bahrain Grand Prix](https://www.formula1.com/en/latest/article.f1-and-coronavirus-what-do-we-know-so-far.5hlhF1oeT6rJbfbUpPMrqI.html)"
-  status: postponed
-  
-- name: "[Formula 1 Vietnam Grand Prix](https://www.formula1.com/en/latest/article.f1-and-coronavirus-what-do-we-know-so-far.5hlhF1oeT6rJbfbUpPMrqI.html)"
-  status: postponed
-
-- name: "[Formula 1 Chinese Grand Prix](https://www.formula1.com/en/latest/article.chinese-grand-prix-postponed-due-to-coronavirus-outbreak.3g2y5Ngyrk1MbNxQB9hj4s.html)"
-  status: postponed
+- name: "[Formula 1](https://www.bbc.com/sport/formula1/51964883)"
+  status: All races through Monaco GP postponed (tentative season start is Azerbaijan in June)
   
 - name: "[Formula 1 Joburg Festival, South Africa](https://www.formula1.com/en/latest/article.f1-joburg-festival-postponed-as-covid-19-precaution.wzjqLLeKvjgDSZMOr4thK.html)"
   status: postponed


### PR DESCRIPTION
Now that all races are postponed through the end of May, there's
no reason to list them all individually.

Adds or updates the following companies, events, or universities:
 - F1

### Checklist

#### Event updates
 - [x] I have linked to the article about the change, not the event's homepage
