### PR TITLE
Add Bitly

### DIFF
--- a/_data/companies/bitly.yml
+++ b/_data/companies/bitly.yml
@@ -1,0 +1,6 @@
+name: Bitly
+wfh: Required
+travel: Restricted
+visitors: Restricted
+events: Restricted
+last_update: 2020-03-20


### PR DESCRIPTION
Adds or updates the following companies, events, or universities:

Bitly

"We have made the decision to extend our office closure through Friday, April 10th."

### Checklist

#### Company updates
 - [X] I have put the most recent relevant date in the "Last Update" column
 - [X] I have linked to the article about the change, not the company's homepage (Please put N/A if there is no public post) - N/A

#### Event updates
 - [ ] I have linked to the article about the change, not the event's homepage

#### University updates
 - [ ] I have linked to the article about the change, not the university's homepage
