### PR TITLE
PyCon US is cancelled

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -385,6 +385,9 @@
 - name: "[PyCon SK](https://2020.pycon.sk/en/news.html)"
   status: moved to September
 
+- name: "[PyCon US](https://pycon.blogspot.com/2020/03/pycon-us-2020-in-pittsburgh.html)"
+  status: cancelled
+
 - name: "[Qt World Summit](https://www.qt.io/qtws20)"
   status: postponed to October 2020
 


### PR DESCRIPTION
Adds or updates the following companies, events, or universities:
 - PyCon US

### Checklist

#### Company updates
 - [ ] I have put the most recent relevant date in the "Last Update" column
 - [ ] I have linked to the article about the change, not the company's homepage (Please put N/A if there is no public post)

#### Event updates
 - [x] I have linked to the article about the change, not the event's homepage

#### University updates
 - [ ] I have linked to the article about the change, not the university's homepage
