### PR TITLE
Google I/O is now outright canceled

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -217,8 +217,8 @@
 - name: "[Google Cloud Next](https://cloud.withgoogle.com/next/sf/)"
   status: online-only
 
-- name: "[Google I/O](https://events.google.com/io/)"
-  status: online-only
+- name: "[Google I/O](https://mobile.twitter.com/googledevs/status/1241077131993427968)"
+  status: cancelled
 
 - name: "[Google News Initiative Summit](http://socialbarrel.com/google-cancels-its-two-day-global-news-initiative-summit-over-coronavirus/123795/)"
   status: cancelled


### PR DESCRIPTION
Adds or updates the following companies, events, or universities:
 - Google I/O
 - 

### Checklist

#### Company updates
 - [ ] I have put the most recent relevant date in the "Last Update" column
 - [ ] I have linked to the article about the change, not the company's homepage (Please put N/A if there is no public post)

#### Event updates
 - [x] I have linked to the article about the change, not the event's homepage

#### University updates
 - [ ] I have linked to the article about the change, not the university's homepage
