### PR TITLE
Update Fernish WFH status

### DIFF
--- a/_data/companies/fernish.yml
+++ b/_data/companies/fernish.yml
@@ -1,7 +1,7 @@
 ---
 name: Fernish
-wfh: Strongly Encouraged
+wfh: Required
 travel: Restricted
 visitors: Restricted
 events: Restricted
-last_update: 2020-03-14
+last_update: 2020-03-22


### PR DESCRIPTION
Adds or updates the following companies, events, or universities:
 - Update Fernish WFH status

### Checklist

#### Company updates
 - [x] I have put the most recent relevant date in the "Last Update" column
 - [x] I have linked to the article about the change, not the company's homepage (Please put N/A if there is no public post)

