### PR TITLE
Computex 2020 is postponed to September

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -97,6 +97,9 @@
 - name: "[Collision](https://collisionconf.com/)"
   status: moving to virtual event
 
+- name: "[COMPUTEX Taipei 2020](https://www.computextaipei.com.tw/en_US/news/info.html?id=E615059E0DC04F10)"
+  status: rescheduled to September 28-30
+
 - name: "[Crestron Masters 2020](https://www.crestron.com/Training-Events/Masters-2020)"
   status: postponed
 


### PR DESCRIPTION
Adds or updates the following companies, events, or universities:
 - Computex
 - 

### Checklist

#### Company updates
 - [ ] I have put the most recent relevant date in the "Last Update" column
 - [ ] I have linked to the article about the change, not the company's homepage (Please put N/A if there is no public post)

#### Event updates
 - [x] I have linked to the article about the change, not the event's homepage

#### University updates
 - [ ] I have linked to the article about the change, not the university's homepage
