### PR TITLE
Python conference updates

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -397,7 +397,7 @@
 - name: "[PyCon US](https://pycon.blogspot.com/2020/03/pycon-us-2020-in-pittsburgh.html)"
   status: cancelled with some online components
 
-- name: "[PyOhio](https://www.pyohio.org/2020/)"
+- name: "[PyOhio](https://twitter.com/PyOhio/status/1245397709965733890)"
   status: in-person event cancelled, evaluating online options
 
 - name: "[Qt World Summit](https://www.qt.io/qtws20)"

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -395,7 +395,7 @@
   status: moved to September
 
 - name: "[PyCon US](https://pycon.blogspot.com/2020/03/pycon-us-2020-in-pittsburgh.html)"
-  status: cancelled
+  status: cancelled with some online components
 
 - name: "[Qt World Summit](https://www.qt.io/qtws20)"
   status: postponed to October 2020

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -388,6 +388,9 @@
 - name: "[PyCon Italia](https://pycon.it/en/blog/pycon-11-postponed-to-november)"
   status: moved to November
 
+- name: "[PyCon KR](https://twitter.com/PyConKR/status/1245249954374811649)"
+  status: online
+
 - name: "[PyCon SK](https://2020.pycon.sk/en/news.html)"
   status: moved to September
 

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -397,6 +397,9 @@
 - name: "[PyCon US](https://pycon.blogspot.com/2020/03/pycon-us-2020-in-pittsburgh.html)"
   status: cancelled with some online components
 
+- name: "[PyOhio](https://www.pyohio.org/2020/)"
+  status: in-person event cancelled, evaluating online options
+
 - name: "[Qt World Summit](https://www.qt.io/qtws20)"
   status: postponed to October 2020
 


### PR DESCRIPTION
Adds or updates the following companies, events, or universities:
 - PyCon KR moving to online-only
 - PyOhio in-person cancelled (virtual TBD)
 - PyCon US adding a virtual component

### Checklist

#### Event updates
 - [x] I have linked to the article about the change, not the event's homepage
