### PR TITLE
SalesDoubler company

### DIFF
--- a/_data/companies/salesdoubler.yml
+++ b/_data/companies/salesdoubler.yml
@@ -1,0 +1,6 @@
+name: SalesDoubler
+wfh: Strongly Encouraged
+travel: Restricted
+visitors: Restricted
+events: Restricted
+last_update: 2020-04-07


### PR DESCRIPTION
Has been added a SalesDoubler.com.ua to the list of companies who are stayed at home

Adds or updates the following companies, events, or universities:
 - 
 - 

### Checklist

#### Company updates
 - [ ] I have put the most recent relevant date in the "Last Update" column
 - [ ] I have linked to the article about the change, not the company's homepage (Please put N/A if there is no public post)

#### Event updates
 - [ ] I have linked to the article about the change, not the event's homepage

#### University updates
 - [ ] I have linked to the article about the change, not the university's homepage
