### PR TITLE
San Diego Comic Con is canceled

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -439,6 +439,9 @@
 - name: "[Salesforce World Tour Sydney](https://www.salesforce.com/au/events/worldtour/syd20/overview/)"
   status: in-person canceled; online-only event
 
+- name: "[San Diego Comic Con 2020](https://io9.gizmodo.com/san-diego-comic-con-2020-is-canceled-1842922379)"
+  status: cancelled
+
 - name: "[SAP Ariba LIVE](https://twitter.com/SAPAriba/status/1235043870250958854?s=20)"
   status: cancelled
 


### PR DESCRIPTION
Adds or updates the following companies, events, or universities:
 - San Diego Comic Con 2020
 - 

### Checklist

#### Company updates
 - [ ] I have put the most recent relevant date in the "Last Update" column
 - [ ] I have linked to the article about the change, not the company's homepage (Please put N/A if there is no public post)

#### Event updates
 - [x] I have linked to the article about the change, not the event's homepage

#### University updates
 - [ ] I have linked to the article about the change, not the university's homepage
