### PR TITLE
Facebook cancels all 50+ person events through 2021

### DIFF
--- a/_data/companies/facebook.yml
+++ b/_data/companies/facebook.yml
@@ -3,5 +3,5 @@ name: Facebook
 wfh: Required
 travel: Canceled
 visitors: Canceled
-events: Virtual only
-last_update: 2020-03-17
+events: Virtual only; Large events [cancelled through July 2021](https://www.engadget.com/facebook-cancels-events-june-2021-181510686.html)
+last_update: 2020-04-20

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -176,7 +176,7 @@
   status: moving to virtual event
 
 - name: "[Facebook F8](https://developers.facebook.com/blog/post/2020/02/27/important-f8-2020-update/)"
-  status: moving to a primarily online event
+  status: "moving to a primarily online event for 2020 [and 2021](https://www.engadget.com/facebook-cancels-events-june-2021-181510686.html)"
 
 - name: "[Facebook Global Marketing Summit](https://www.businessinsider.com/how-facebook-affected-novel-coronavirus-outbreak-2020-2)"
   status: cancelled


### PR DESCRIPTION
Adds or updates the following companies, events, or universities:
 - Facebook (including F8 2021)

### Checklist

#### Company updates
 - [x] I have put the most recent relevant date in the "Last Update" column
 - [x] I have linked to the article about the change, not the company's homepage (Please put N/A if there is no public post)

#### Event updates
 - [x] I have linked to the article about the change, not the event's homepage
